### PR TITLE
Dmm crawler fix

### DIFF
--- a/src/models/base/web.py
+++ b/src/models/base/web.py
@@ -562,7 +562,7 @@ def get_avsox_domain():
 
 def get_amazon_data(req_url):
     """
-    获取 Amazon 数据，修改地区为540-0002
+    获取 Amazon 数据
     """
     headers = {
         "accept-encoding": "gzip, deflate, br",
@@ -595,70 +595,6 @@ def get_amazon_data(req_url):
 
         if not result:
             return False, html_info
-
-    if "540-0002" not in html_info:
-        try:
-            # 获取 anti_csrftoken_a2z
-            anti_csrftoken_a2z = re.findall(r"anti-csrftoken-a2z([^}]+)", html_info)[0].replace("&quot;", "").strip(":")
-            session_id = re.findall(r'sessionId: "([^"]+)', html_info)[0]
-            ubid_acbjp = ""
-            if "ubid-acbjp" in str(result):
-                try:
-                    ubid_acbjp = result["set-cookie"]
-                except:
-                    try:
-                        ubid_acbjp = re.findall(r"ubid-acbjp=([^ ]+)", str(result))[0]
-                    except:
-                        pass
-            headers_o = {
-                "Anti-csrftoken-a2z": anti_csrftoken_a2z,
-                "cookie": f"session-id={session_id}; ubid_acbjp={ubid_acbjp}",
-            }
-            headers.update(headers_o)
-            mid_url = (
-                "https://www.amazon.co.jp/portal-migration/hz/glow/get-rendered-toaster"
-                "?pageType=Search&aisTransitionState=in&rancorLocationSource=REALM_DEFAULT&_="
-            )
-            result, html = curl_html(mid_url, headers=headers)
-            try:
-                anti_csrftoken_a2z = re.findall(r'csrfToken="([^"]+)', html)[0]
-                ubid_acbjp = re.findall(r"ubid-acbjp=([^ ]+)", str(result))[0]
-            except:
-                pass
-
-            # 修改配送地址为日本，这样结果多一些
-            headers_o = {
-                "Anti-csrftoken-a2z": anti_csrftoken_a2z,
-                "Content-length": "140",
-                "Content-Type": "application/json",
-                "cookie": f"session-id={session_id}; ubid_acbjp={ubid_acbjp}",
-            }
-            headers.update(headers_o)
-            post_url = "https://www.amazon.co.jp/portal-migration/hz/glow/address-change?actionSource=glow"
-            data = {
-                "locationType": "LOCATION_INPUT",
-                "zipCode": "540-0002",
-                "storeContext": "generic",
-                "deviceType": "web",
-                "pageType": "Search",
-                "actionSource": "glow",
-            }
-            result, html = post_html(post_url, json=data, headers=headers)
-            if result:
-                if "540-0002" in str(html):
-                    headers = {
-                        "Host": "www.amazon.co.jp",
-                        "User-Agent": get_user_agent(),
-                    }
-                    result, html_info = curl_html(req_url, headers=headers)
-                else:
-                    print("Amazon 修改地区失败: ", req_url, str(result), str(html))
-            else:
-                print("Amazon 修改地区异常: ", req_url, str(result), str(html))
-
-        except Exception as e:
-            print("Amazon 修改地区出错: ", req_url, str(e))
-            print(traceback.format_exc())
 
     return result, html_info
 

--- a/src/models/base/web.py
+++ b/src/models/base/web.py
@@ -457,8 +457,8 @@ def check_url(url, length=False, real_url=False):
                 else:
                     return 0
 
-            # 状态码 > 299，表示请求失败，视为不可用
-            if r.status_code > 299:
+            # 状态码 > 299，表示请求失败，视为不可用, 405 表示请求方法不支持, 改为GET单独处理
+            if r.status_code > 299 and r.status_code != 405:
                 error_info = f"{r.status_code} {url}"
                 signal.add_log(f"🔴 请求失败！ 重试: [{j + 1}/{retry_times}] {error_info}")
                 continue
@@ -488,7 +488,7 @@ def check_url(url, length=False, real_url=False):
                     signal.add_log(f"🔴 检测未通过！当前图片已被网站删除 {url}")
                     return 0
 
-            # 获取文件大小。如果没有获取到文件大小或请求方法不被允许，尝试下载15k数据，如果失败，视为不可用
+            # 获取文件大小。如果没有获取到文件大小或 状态码 = 405，尝试下载15k数据，如果失败，视为不可用
             content_length = r.headers.get("Content-Length")
             if not content_length or r.status_code == 405:
                 response = requests.get(
@@ -500,9 +500,9 @@ def check_url(url, length=False, real_url=False):
                     i += 1
                     if i == 3:
                         response.close()
-                        signal.add_log(f"✅ 检测通过！未返回大小，预下载15k通过 {true_url}")
+                        signal.add_log(f"✅ 检测通过！预下载15k通过 {true_url}")
                         return 10240 if length else true_url
-                signal.add_log(f"🔴 检测未通过！未返回大小，预下载15k失败 {true_url}")
+                signal.add_log(f"🔴 检测未通过！预下载15k失败 {true_url}")
                 return 0
 
             # 如果返回内容的文件大小 < 8k，视为不可用

--- a/src/models/base/web.py
+++ b/src/models/base/web.py
@@ -488,9 +488,9 @@ def check_url(url, length=False, real_url=False):
                     signal.add_log(f"🔴 检测未通过！当前图片已被网站删除 {url}")
                     return 0
 
-            # 获取文件大小。如果没有获取到文件大小，尝试下载15k数据，如果失败，视为不可用
+            # 获取文件大小。如果没有获取到文件大小或请求方法不被允许，尝试下载15k数据，如果失败，视为不可用
             content_length = r.headers.get("Content-Length")
-            if not content_length:
+            if not content_length or r.status_code == 405:
                 response = requests.get(
                     true_url, headers=headers, proxies=proxies, timeout=timeout, verify=False, stream=True
                 )

--- a/src/models/crawlers/dmm.py
+++ b/src/models/crawlers/dmm.py
@@ -98,9 +98,11 @@ def get_tag(html):
 
 
 def get_cover(html):
-    result = html.xpath('//a[@name="package-image"]/@href')
-    result = re.sub(r"pics.dmm.co.jp", r"awsimgsrc.dmm.co.jp/pics_dig", result[0])
-    return result if result else ""
+    result = html.xpath('//a[@id="sample-image1"]/img/@src')
+    if result:
+        # 替换域名并返回第一个匹配项
+        return re.sub(r'pics.dmm.co.jp', r'awsimgsrc.dmm.co.jp/pics_dig', result[0])
+    return ''  # 无匹配时返回空字符串
 
 
 def get_poster(html, cover):

--- a/src/models/crawlers/dmm.py
+++ b/src/models/crawlers/dmm.py
@@ -106,12 +106,12 @@ def get_cover(html):
 
 
 def get_poster(html, cover):
-    result = html.xpath('//img[@class="tdmm"]/@src')
+    result = html.xpath('//meta[@property="og:image"]/@content')
     if result:
         result = re.sub(r"pics.dmm.co.jp", r"awsimgsrc.dmm.co.jp/pics_dig", result[0])
         return result
     else:
-        return cover.replace("pt.jpg", "ps.jpg")
+        return cover.replace("pl.jpg", "ps.jpg")
 
 
 def get_extrafanart(html):

--- a/src/models/crawlers/dmm.py
+++ b/src/models/crawlers/dmm.py
@@ -98,21 +98,21 @@ def get_tag(html):
 
 
 def get_cover(html, real_url):
-    if "dmm.co.jp" in real_url:
+    if "mono/dvd" in real_url:
+        result = html.xpath('//meta[@property="og:image"]/@content')
+        if result:
+           return result[0]
+    elif "dmm.co.jp" in real_url:
         result = html.xpath('//a[@id="sample-image1"]/img/@src')
         if result:
             # 替换域名并返回第一个匹配项
             return re.sub(r'pics.dmm.co.jp', r'awsimgsrc.dmm.co.jp/pics_dig', result[0])
-    elif "dmm.com" in real_url:
-        result = html.xpath('//meta[@property="og:image"]/@content')
-        if result:
-            return result
     return ''  # 无匹配时返回空字符串
 
 
-def get_poster(html, cover):
+def get_poster(html, cover, real_url):
     result = html.xpath('//meta[@property="og:image"]/@content')
-    if result:
+    if result and "dmm.co.jp/digital" in real_url:
         result = re.sub(r"pics.dmm.co.jp", r"awsimgsrc.dmm.co.jp/pics_dig", result[0])
         return result
     else:
@@ -633,7 +633,7 @@ def main(number, appoint_url="", log_info="", req_web="", language="jp", file_pa
                 studio = get_studio(html)
                 publisher = get_publisher(html, studio)
                 extrafanart = get_extrafanart(html, real_url)
-                poster_url = get_poster(html, cover_url)
+                poster_url = get_poster(html, cover_url, real_url)
                 trailer = get_trailer(htmlcode, real_url)
                 mosaic = get_mosaic(html)
             except Exception as e:
@@ -768,4 +768,5 @@ if __name__ == "__main__":
     # print(main('stars-779'))
     # print(main('FAKWM-001', 'https://tv.dmm.com/vod/detail/?season=5497fakwm00001'))
     # print(main('FAKWM-064', 'https://tv.dmm.com/vod/detail/?season=5497fakwm00064'))
+    # print(main('IPZ-791'))
     pass

--- a/src/models/crawlers/dmm.py
+++ b/src/models/crawlers/dmm.py
@@ -123,7 +123,14 @@ def get_poster(html, cover, real_url):
 
 def get_extrafanart(html, real_url):
     result = []
-    if "dmm.co.jp" in real_url:
+    if "mono/dvd" in real_url:
+        result_list = html.xpath("//a[@name='sample-image']/img/@data-lazy")
+        i = 1
+        for each in result_list:
+            each = each.replace("-%s.jpg" % i, "jp-%s.jpg" % i)
+            result.append(each)
+            i += 1
+    elif "dmm.co.jp" in real_url:
         result_list = html.xpath("//div[@id='sample-image-block']/a/img/@src")
         if not result_list:
             result_list = html.xpath("//a[@name='sample-image']/img/@src")
@@ -142,12 +149,18 @@ def get_director(html):
     return result[0] if result else ""
 
 
-def get_ountline(html):
-    result = html.xpath(
-        "normalize-space(string(//div[@class='wp-smplex']/preceding-sibling::div[contains(@class, 'mg-b20')][1]))"
-    )
-    result = result.split("※ 配信方法")[0]
-    return result.replace("「コンビニ受取」対象商品です。詳しくはこちらをご覧ください。", "").strip()
+def get_outline(html, real_url):
+    result = ""
+    if "mono/dvd" in real_url:
+        result = html.xpath("normalize-space(string(//div[@class='mg-b20 lh4']/p[@class='mg-b20']))")
+        return result if result else ""
+    elif "dmm.co.jp" in real_url:
+        result = html.xpath(
+            "normalize-space(string(//div[@class='wp-smplex']/preceding-sibling::div[contains(@class, 'mg-b20')][1]))"
+        )
+        result = result.split("※ 配信方法")[0]
+        return result.replace("「コンビニ受取」対象商品です。詳しくはこちらをご覧ください。", "").strip()
+    return result
 
 
 def get_score(html):
@@ -674,7 +687,7 @@ def main(number, appoint_url="", log_info="", req_web="", language="jp", file_pa
             try:
                 actor = get_actor(html)  # 获取演员
                 cover_url = get_cover(html, real_url)  # 获取 cover
-                outline = get_ountline(html)
+                outline = get_outline(html, real_url)
                 tag = get_tag(html)
                 release = get_release(html)
                 year = get_year(release)
@@ -824,4 +837,6 @@ if __name__ == "__main__":
     # print(main('FPRE-113'))
     # print(main('fpre00113'))
     # print(main('FPRE113'))
+    # print(main('ABF-164'))
+    # print(main('ABF-203'))
     pass


### PR DESCRIPTION
### 20250401 fix
**变更**
dmm搜索页面变更为Next.js框架. 服务端只会生成基本HTML结构，其他交由客户端JavaScript动态渲染, 原先的静态html爬取已无法获取完整信息.

**修复**
使用playwright模拟浏览器行为获取完整 HTML，再用 lxml 解析

**影响**
1. 由于新增了playwright工具, 打包后体积增加了30%, 运行将会占用更多系统资源
2. 启动速度进一步变慢, 接近半分钟
3. 由于需要等待playwright加载, 刮削性能降低, 耗时更长
4. 需要手动下载playwright依赖的浏览器文件, 并且修改系统环境变量